### PR TITLE
mention press mail alias and mattermost

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -24,6 +24,6 @@ de:
     Wissenschaft oder in Menschenrechtsorganisationen. Wir möchten einen Teil unserer Zeit investieren, um einen Beitrag zur
     Verbesserung der globalen Gesellschaft zu leisten."
   hacker_p3: "Wenn du zur Diskussion beitragen oder aktiv helfen möchtest, melde dich am besten zuerst für unsere
-    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a>."
+    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an."
   footer: "Für generelle Anfragen, sende bitte eine Email an <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. Presseanfragen bitte an <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>
     Für Unterstützungsanfragen benutz bitte den speziell gesicherten Link oben auf der Seite."

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -24,6 +24,6 @@ de:
     Wissenschaft oder in Menschenrechtsorganisationen. Wir möchten einen Teil unserer Zeit investieren, um einen Beitrag zur
     Verbesserung der globalen Gesellschaft zu leisten."
   hacker_p3: "Wenn du zur Diskussion beitragen oder aktiv helfen möchtest, melde dich am besten zuerst für unsere
-    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an."
-  footer: "Für generelle Anfragen, sende bitte eine Email an <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>.
+    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an oder unseren <a href=\"https://chat.securitywithoutborders.org."\">öffentliche Mattermost Chat-Server</a>."
+  footer: "Für generelle Anfragen, sende bitte eine Email an <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. Presseanfragen bitte an <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>
     Für Unterstützungsanfragen benutz bitte den speziell gesicherten Link oben auf der Seite."

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -24,6 +24,6 @@ de:
     Wissenschaft oder in Menschenrechtsorganisationen. Wir möchten einen Teil unserer Zeit investieren, um einen Beitrag zur
     Verbesserung der globalen Gesellschaft zu leisten."
   hacker_p3: "Wenn du zur Diskussion beitragen oder aktiv helfen möchtest, melde dich am besten zuerst für unsere
-    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an oder unseren <a href=\"https://chat.securitywithoutborders.org\">öffentliche Mattermost Chat-Server</a>."
+    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a>."
   footer: "Für generelle Anfragen, sende bitte eine Email an <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. Presseanfragen bitte an <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>
     Für Unterstützungsanfragen benutz bitte den speziell gesicherten Link oben auf der Seite."

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -24,6 +24,6 @@ de:
     Wissenschaft oder in Menschenrechtsorganisationen. Wir möchten einen Teil unserer Zeit investieren, um einen Beitrag zur
     Verbesserung der globalen Gesellschaft zu leisten."
   hacker_p3: "Wenn du zur Diskussion beitragen oder aktiv helfen möchtest, melde dich am besten zuerst für unsere
-    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an oder unseren <a href=\"https://chat.securitywithoutborders.org."\">öffentliche Mattermost Chat-Server</a>."
+    <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an oder unseren <a href=\"https://chat.securitywithoutborders.org\">öffentliche Mattermost Chat-Server</a>."
   footer: "Für generelle Anfragen, sende bitte eine Email an <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. Presseanfragen bitte an <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>
     Für Unterstützungsanfragen benutz bitte den speziell gesicherten Link oben auf der Seite."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,6 +30,6 @@ en:
     organizations. We want to dedicate some of our time to the betterment of
     global society."
   hacker_p3: "If you would like to join the discussion and volunteer, the
-    best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>or our <a href=\"https://chat.securitywithoutborders.org."\">public Mattermost Chat-Server</a>."
+    best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>or our <a href=\"https://chat.securitywithoutborders.org\">public Mattermost Chat-Server</a>."
   footer: "For general inquiries, please send an email to <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. For press inquiries, contact <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>.
     For assistance requests, please use the more secure link at the top of the page."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,6 +30,6 @@ en:
     organizations. We want to dedicate some of our time to the betterment of
     global society."
   hacker_p3: "If you would like to join the discussion and volunteer, the
-    best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>or our <a href=\"https://chat.securitywithoutborders.org\">public Mattermost Chat-Server</a>."
+    best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>."
   footer: "For general inquiries, please send an email to <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. For press inquiries, contact <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>.
     For assistance requests, please use the more secure link at the top of the page."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,6 +30,6 @@ en:
     organizations. We want to dedicate some of our time to the betterment of
     global society."
   hacker_p3: "If you would like to join the discussion and volunteer, the
-    best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>."
-  footer: "For general inquiries, please send an email to <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>.
+    best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>or our <a href=\"https://chat.securitywithoutborders.org."\">public Mattermost Chat-Server</a>."
+  footer: "For general inquiries, please send an email to <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. For press inquiries, contact <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>.
     For assistance requests, please use the more secure link at the top of the page."


### PR DESCRIPTION
Based on the medium article it should be okay to mention press mail alias on the page as well as the mattermost chat server to keep people joining the chat server.