### PR TITLE
[RFR] Add footer link to Code of Conduct

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -28,3 +28,4 @@ de:
     <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">öffentliche Mailingliste</a> an."
   footer: "Für generelle Anfragen, sende bitte eine Email an <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. Presseanfragen bitte an <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>
     Für Unterstützungsanfragen benutz bitte den speziell gesicherten Link oben auf der Seite."
+  code_of_conduct: "Code of Conduct"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -34,3 +34,4 @@ en:
     best place to start is to subscribe to our <a href=\"https://lists.securitywithoutborders.org/mailman/listinfo/swb-public\">public mailing list</a>."
   footer: "For general inquiries, please send an email to <a href=\"mailto:info@securitywithoutborders.org\">info@securitywithoutborders.org</a>. For press inquiries, contact <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>.
     For assistance requests, please use the more secure link at the top of the page."
+  code_of_conduct: "Code of Conduct"

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -39,3 +39,4 @@ gr:
     <a href=\"mailto:press@securitywithoutborders.org\">press@securitywithoutborders.org</a>.
     Για αίτηση βοήθειας, παρακαλούμε να έρθετε σε επαφή μαζί μας κάνοντας κλικ στο <i>Ζητήστε Βοήθεια</i>
     κουμπί στην αρχή της σελίδας και συμπληρώνοντας τη φόρμα που θα ακολουθήσει."
+  code_of_conduct: "Code of Conduct"

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -13,5 +13,7 @@
     <%= partial "layouts/partials/header" %>
 
     <%= yield %>
+
+    <%= partial "layouts/partials/footer" %>
   </body>
 </html>

--- a/source/layouts/partials/_footer.erb
+++ b/source/layouts/partials/_footer.erb
@@ -1,0 +1,11 @@
+<footer class="footer">
+  <div class="container">
+    <ul class="footer__inner">
+      <li>
+        <a href="https://github.com/securitywithoutborders/organization/blob/master/code-of-conduct.md">
+          <%= t(:code_of_conduct) %>
+        </a>
+      </li>
+    <ul>
+  </div>
+</footer>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -40,7 +40,7 @@
             </p>
         </div>
     </div>
-    <div class="row footer">
+    <div class="row">
         <div class="one column">
             <p><!-- filler --></p>
         </div>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -3,6 +3,8 @@
 @import 'fonts';
 @import 'skeleton';
 
+$background--dark: #1e1e1e;
+
 body {
   background-color: #e1e1e1;
 }
@@ -11,7 +13,7 @@ body {
   position: relative;
   margin-top: 0;
   text-align: center;
-  background-color: #1e1e1e;
+  background-color: $background--dark;
   margin-bottom: 3rem;
 }
 
@@ -56,11 +58,6 @@ body {
 
 h1 {
   margin-bottom: 3rem;
-}
-
-.footer {
-  margin-top: 1rem;
-  text-align: center;
 }
 
 .container {
@@ -134,4 +131,19 @@ li {
 
 .center-contents {
   text-align: center;
+}
+
+.footer {
+  padding: 1rem 0;
+  background-color: $background--dark;
+}
+
+.footer__inner {
+  margin: 0;
+  display: flex;
+  align-items: center;
+}
+
+.footer__inner li {
+  margin: 0;
 }


### PR DESCRIPTION
Just links to the Github document for now.

In a follow-up PR, would be nice to have `middleman` pull the markdown contents from Github and render it onto a page during the site-build. But then we need to have the document translated too...